### PR TITLE
Append details on parameters to expanded function docstrings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - 2.6
   - 2.7

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+requirements.txt

--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -317,13 +317,6 @@ class parameterized(object):
             """
 
         def parameterized_expand_wrapper(f, instance=None):
-            # Throw a runtime error if the very first argument is
-            # not self. Either the code is not PEP8 compliant, or
-            # this is not a method, and parameterized.expand
-            # can only be used on methods.
-            if inspect.getargspec(f).args[0] != "self":
-                raise RuntimeError("First argument must be 'self'.")
-
             stack = inspect.stack()
             frame = stack[1]
             frame_locals = frame[0].f_locals

--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -121,11 +121,12 @@ def parameterized_argument_value_pairs(func, p):
             [("foo", 1), ("*args", (16, ))]
     """
     argspec = inspect.getargspec(func)
+    arg_offset = 1 if argspec.args[0] == "self" else 0
 
-    named_args = argspec.args
+    named_args = argspec.args[arg_offset:]
 
     result = zip(named_args, p.args)
-    named_args = argspec.args[len(result):]
+    named_args = argspec.args[len(result) + arg_offset:]
     varargs = p.args[len(result):]
 
     result.extend([

--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -1,7 +1,12 @@
 import re
 import inspect
 from functools import wraps
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 from nose.tools import nottest
 from unittest import TestCase

--- a/nose_parameterized/test.py
+++ b/nose_parameterized/test.py
@@ -27,6 +27,14 @@ missing_tests = set([
     "test_on_TestCase2_custom_name_foo0('foo0', bar=None)",
     "test_on_TestCase2_custom_name_foo1('foo1', bar=None)",
     "test_on_TestCase2_custom_name_foo2('foo2', bar=42)",
+    "test_on_TestCase3_custom_name_42(42, bar=None)",
+    "test_on_TestCase3_custom_name_foo0('foo0', bar=None)",
+    "test_on_TestCase3_custom_name_foo1('foo1', bar=None)",
+    "test_on_TestCase3_custom_name_foo2('foo2', bar=42)",
+    "test_on_TestCase4_custom_name_42(42, bar=None)",
+    "test_on_TestCase4_custom_name_foo0('foo0', bar=None)",
+    "test_on_TestCase4_custom_name_foo1('foo1', bar=None)",
+    "test_on_TestCase4_custom_name_foo2('foo2', bar=42)",
     "test_on_old_style_class('foo')",
     "test_on_old_style_class('bar')",
 ])
@@ -52,6 +60,10 @@ class TestParameterized(object):
 def custom_naming_func(testcase_func, param_num, param):
     return testcase_func.__name__ + '_custom_name_' + str(param.args[0])
 
+def custom_doc_func(testcase_func, param_num, param):
+    return testcase_func.__doc__ + ' ' + str(param.args[0])
+
+
 class TestParamerizedOnTestCase(TestCase):
     @parameterized.expand(test_params)
     def test_on_TestCase(self, foo, bar=None):
@@ -67,6 +79,40 @@ class TestParamerizedOnTestCase(TestCase):
         assert_equal(nose_test_method_name, expected_name,
                      "Test Method name '%s' did not get customized to expected: '%s'" %
                      (nose_test_method_name, expected_name))
+        missing_tests.remove("%s(%r, bar=%r)" %(expected_name, foo, bar))
+
+    @parameterized.expand(test_params,
+                          testcase_func_name=custom_naming_func,
+                          testcase_func_doc=custom_doc_func)
+    def test_on_TestCase3(self, foo, bar=None):
+        """TestCase3 Documentation"""
+        stack = inspect.stack()
+        frame = stack[1]
+        frame_locals = frame[0].f_locals
+        nose_test_method_doc = frame_locals['a'][0]._testMethodDoc
+        expected_doc = "TestCase3 Documentation " + str(foo)
+        expected_name = "test_on_TestCase3_custom_name_" + str(foo)
+        assert_equal(nose_test_method_doc, expected_doc,
+                     "Test Method doc '%s' did not get customized to expected: '%s'" %
+                     (nose_test_method_doc, expected_doc))
+        missing_tests.remove("%s(%r, bar=%r)" %(expected_name, foo, bar))
+
+    @parameterized.expand(test_params,
+                          testcase_func_name=custom_naming_func)
+    def test_on_TestCase4(self, foo, bar=None):
+        """TestCase4 Documentation.
+
+        More"""
+        stack = inspect.stack()
+        frame = stack[1]
+        frame_locals = frame[0].f_locals
+        nose_test_method_doc = frame_locals['a'][0]._testMethodDoc
+        expected_doc = ("TestCase4 Documentation [with foo = %r, bar = %r].\n\n"
+                        "        More" % (foo, bar))
+        expected_name = "test_on_TestCase4_custom_name_" + str(foo)
+        assert_equal(nose_test_method_doc, expected_doc,
+                     "Test Method doc '%s' did not get customized to expected: '%s'" %
+                     (nose_test_method_doc, expected_doc))
         missing_tests.remove("%s(%r, bar=%r)" %(expected_name, foo, bar))
 
 def test_warns_when_using_parameterized_with_TestCase():

--- a/nose_parameterized/test.py
+++ b/nose_parameterized/test.py
@@ -219,8 +219,9 @@ def test_parameterized_argument_value_pairs(func_params, p, expected):
 
 
 @parameterized([
-    ("abcd", "abcd"),
-    ("123456789", "12...89"),
+    ("abcd", "'abcd'"),
+    ("123456789", "'12...89'"),
+    (123456789, "123...789")  # number types do not have quotes, so we can repr more
 ])
-def test_short_repr(input, expected, n=4):
+def test_short_repr(input, expected, n=6):
     assert_equal(short_repr(input, n=n), expected)

--- a/nose_parameterized/test.py
+++ b/nose_parameterized/test.py
@@ -216,6 +216,7 @@ class TestOldStyleClass:
     def test_old_style_classes(self, param):
         missing_tests.remove("test_on_old_style_class(%r)" %(param, ))
 
+
 @parameterized([
     ("foo", param(1), [("foo", 1)]),
     ("foo, *a", param(1), [("foo", 1)]),
@@ -235,6 +236,7 @@ def test_parameterized_argument_value_pairs(func_params, p, expected):
     exec "def helper_func(%s): pass" %(func_params, ) in ns
     actual = parameterized_argument_value_pairs(ns["helper_func"], p)
     assert_equal(actual, expected)
+
 
 @parameterized([
     ("abcd", "abcd"),

--- a/nose_parameterized/test.py
+++ b/nose_parameterized/test.py
@@ -6,7 +6,9 @@ from nose.tools import assert_equal
 from nose.plugins.skip import SkipTest
 
 from .compat import PY3
-from .parameterized import parameterized, param, parameterized_argument_value_pairs
+from .parameterized import (
+    parameterized, param, parameterized_argument_value_pairs, short_repr,
+)
 
 def assert_contains(haystack, needle):
     if needle not in haystack:
@@ -214,7 +216,6 @@ class TestOldStyleClass:
     def test_old_style_classes(self, param):
         missing_tests.remove("test_on_old_style_class(%r)" %(param, ))
 
-
 @parameterized([
     ("foo", param(1), [("foo", 1)]),
     ("foo, *a", param(1), [("foo", 1)]),
@@ -234,3 +235,10 @@ def test_parameterized_argument_value_pairs(func_params, p, expected):
     exec "def helper_func(%s): pass" %(func_params, ) in ns
     actual = parameterized_argument_value_pairs(ns["helper_func"], p)
     assert_equal(actual, expected)
+
+@parameterized([
+    ("abcd", "abcd"),
+    ("123456789", "12...89"),
+])
+def test_short_repr(input, expected, n=4):
+    assert_equal(short_repr(input, n=n), expected)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ordereddict
+nose==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.dirname(sys.argv[0]) or ".")
 
 setup(
     name="nose-parameterized",
-    version="0.3.5",
+    version="0.4.0",
     url="https://github.com/wolever/nose-parameterized",
     author="David Wolever",
     author_email="david@wolever.net",

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,5 @@ setup(
         'License :: OSI Approved :: BSD License',
     ],
     packages=find_packages(),
+    install_requires=["ordereddict", "nose>=1.2.1"]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist=py26,py27,py32,py33,pypy
 
 [testenv]
-deps=nose==1.2.1
+deps=-rrequirements.txt
 commands=nosetests


### PR DESCRIPTION
Test runners will occassionaly use the docstring of a test method
as a means of reporting its execution. Because the docstring is
simply copied from the template method to the parameterized
method, it isn't very useful in distinguishing between tests.

We now detect the names of the parameters of the function and
the arguments that are being passed as parameters and append
that information to the end of the first line of the docstring.

The generated docstrings might not make perfect sense, so the
user can also specify testcase_func_doc to override docstring
generation with information that makes more sense.

Fixes #21