### PR TITLE
Fix: Compatibilty with nose2

### DIFF
--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     MaybeOrderedDict = dict
 
-from nose.tools import nottest
 from unittest import TestCase
 
 PY3 = sys.version_info[0] == 3
@@ -354,7 +353,7 @@ class parameterized(object):
 
                 frame_locals[name] = cls.param_as_standalone_func(p, f, name)
                 frame_locals[name].__doc__ = doc
-            return nottest(f)
+            f.__test__ = False
         return parameterized_expand_wrapper
 
     @classmethod


### PR DESCRIPTION
1) There is no need to import nose here.
2) Parameterized_expand_wrapper method should not return anything, becouse this leave methods of TestCase without arguments for tests and produces errors like this:
TypeError: test_some_test() takes exactly 2 arguments (1 given)

My change will make this library compatible with nose2. (It's compatible with nose and green now)