### PR TITLE
Make defensive copy of parameterized decorator arguments

### DIFF
--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -321,11 +321,12 @@ class parameterized(object):
         return eval("[" + parents + "]", frame[0].f_globals, frame[0].f_locals)
 
     @classmethod
-    def input_as_callable(cls, input):
-        if callable(input):
-            return lambda: cls.check_input_values(input())
-        input_values = cls.check_input_values(input)
-        return lambda: input_values
+    def input_as_callable(cls, input_values):
+        """Return a lambda that returns a defensive copy of the parameters."""
+        if callable(input_values):
+            input_values = input_values()
+        checked_values = tuple(cls.check_input_values(input_values))
+        return lambda: checked_values
 
     @classmethod
     def check_input_values(cls, input_values):


### PR DESCRIPTION
While using this library I encountered a strange situation where certain tests using the `@parameterized` decorator were being skipped silently in CI. The root causes were a mixture of using the nose's builtin multiprocessing and generators as arguments to `@parameterized` instead of lists.

Here's a simple test case to demonstrate the behaviour.

```python
from nose_parameterized import parameterized


def get_generator():
    yield 1, 2, 3
    yield 4, 5, 6


@parameterized(get_generator())
def test_stuff(a, b, c):
    pass
```

Then in the terminal it runs fine with vanilla options...
```
$ nosetests
..
----------------------------------------------------------------------
Ran 2 tests in 0.011s

OK
```

... but the test is simply ignored when using nose multiprocessing!
```
$ nosetests --processes 2

----------------------------------------------------------------------
Ran 0 tests in 0.038s

OK
```

Somehow, during multiprocessing, the values passed to `@parameterized` are consumed _more than once_ and on the second time the generator/iterator is exhausted and appears to be empty.

To solve this problem I tried at first to validate that values passed in to `@parameterized` were not of certain `types.GeneratorType` and `collections.Iterator` types, but I found it very hard to cover all the bases. Instead, this PR submits a change which makes a shallow defensive copy of the input to `@parameterized` to ensure it can be consumed more than once and thus succeed in multiprocessing scenarios.

Thanks for taking a look!