### PR TITLE
Adds license information to the setup function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     name="nose-parameterized",
     version="0.6.dev",
     url="https://github.com/wolever/nose-parameterized",
+    license="FreeBSD",
     author="David Wolever",
     author_email="david@wolever.net",
     description="Parameterized testing with any Python test framework",


### PR DESCRIPTION
Adding it as FreeBSD as mentioned in
https://en.wikipedia.org/wiki/BSD_licenses#2-clause_license_.28.22Simplified_BSD_License.22_or_.22FreeBSD_License.22.29
FSF prefers the term FreeBSD over Simplified BSD or 2-clause BSD as the license
name.